### PR TITLE
fix the bug of do.call function in R6 object.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BulkRnaSeqTool
 Title: Bulk RNAseq Analysis Integrated Toolkit
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     person("Fanghan", "Ji", , "jifanghan1@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0005-0422-8092"))

--- a/R/01_BulkRNASeqAnalysis_class.R
+++ b/R/01_BulkRNASeqAnalysis_class.R
@@ -99,7 +99,7 @@ BulkRNASeqAnalysis <- R6::R6Class(
             # 执行任务函数
             result <- do.call(
               task$func,
-              c(list(self = self), full_params)
+              c(full_params)
             )
 
             # 保存结果


### PR DESCRIPTION
when building a analysis object, question which warning param of self not being used in pipeline building jumped out.So, I found extra self param in do.call function which pass invalid R6 params. @hANjishuai 